### PR TITLE
feat: frontmatterユーティリティ + read / list ツール実装

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,15 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { readArticleSchema, readArticle } from "./tools/read-article.js";
+import { listArticlesSchema, listArticles } from "./tools/list-articles.js";
 
 const server = new McpServer({
   name: "zenn-content",
   version: "0.1.0",
 });
 
-// Tools will be registered here in subsequent issues
+server.tool("zenn_read_article", "指定した記事の全内容を返す", readArticleSchema, readArticle);
+server.tool("zenn_list_articles", "記事一覧を取得する", listArticlesSchema, listArticles);
 
 async function main() {
   const transport = new StdioServerTransport();

--- a/src/tools/list-articles.ts
+++ b/src/tools/list-articles.ts
@@ -1,0 +1,54 @@
+import { readFileSync, readdirSync } from "fs";
+import { basename } from "path";
+import { z } from "zod";
+import { getArticlesDir } from "../utils/zenn-path.js";
+import { parseArticle } from "../utils/frontmatter.js";
+
+export const listArticlesSchema = {
+  status: z
+    .enum(["all", "draft", "published"])
+    .default("all")
+    .describe("フィルター: all / draft / published"),
+};
+
+export async function listArticles({ status }: { status: string }) {
+  const articlesDir = getArticlesDir();
+
+  let files: string[];
+  try {
+    files = readdirSync(articlesDir).filter((f) => f.endsWith(".md"));
+  } catch {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `articles ディレクトリが見つかりません: ${articlesDir}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  const articles = files.map((file) => {
+    const raw = readFileSync(`${articlesDir}/${file}`, "utf-8");
+    const { frontmatter } = parseArticle(raw);
+    const slug = basename(file, ".md");
+    return {
+      slug,
+      ...frontmatter,
+      path: `articles/${file}`,
+    };
+  });
+
+  const filtered = articles.filter((a) => {
+    if (status === "draft") return !a.published;
+    if (status === "published") return a.published;
+    return true;
+  });
+
+  return {
+    content: [
+      { type: "text" as const, text: JSON.stringify(filtered, null, 2) },
+    ],
+  };
+}

--- a/src/tools/read-article.ts
+++ b/src/tools/read-article.ts
@@ -1,0 +1,41 @@
+import { readFileSync, existsSync } from "fs";
+import { z } from "zod";
+import { getArticlePath } from "../utils/zenn-path.js";
+import { parseArticle } from "../utils/frontmatter.js";
+
+export const readArticleSchema = {
+  slug: z.string().describe("記事のslug（ファイル名から拡張子を除いたもの）"),
+};
+
+export async function readArticle({ slug }: { slug: string }) {
+  const filePath = getArticlePath(slug);
+
+  if (!existsSync(filePath)) {
+    return {
+      content: [
+        { type: "text" as const, text: `記事が見つかりません: ${slug}` },
+      ],
+      isError: true,
+    };
+  }
+
+  const raw = readFileSync(filePath, "utf-8");
+  const article = parseArticle(raw);
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            slug,
+            ...article.frontmatter,
+            body: article.body,
+          },
+          null,
+          2
+        ),
+      },
+    ],
+  };
+}

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -1,0 +1,26 @@
+import matter from "gray-matter";
+
+export interface ZennFrontmatter {
+  title: string;
+  emoji: string;
+  type: "tech" | "idea";
+  topics: string[];
+  published: boolean;
+}
+
+export interface ZennArticle {
+  frontmatter: ZennFrontmatter;
+  body: string;
+}
+
+export function parseArticle(content: string): ZennArticle {
+  const { data, content: body } = matter(content);
+  return {
+    frontmatter: data as ZennFrontmatter,
+    body: body.trimStart(),
+  };
+}
+
+export function stringifyArticle(article: ZennArticle): string {
+  return matter.stringify("\n" + article.body, article.frontmatter);
+}


### PR DESCRIPTION
## Summary
- `src/utils/frontmatter.ts`: `gray-matter` によるZenn記事のパース・シリアライズユーティリティ
- `zenn_read_article`: 指定slugの記事全文（frontmatter + 本文）を返すツール
- `zenn_list_articles`: `articles/*.md` を一覧取得（`all` / `draft` / `published` フィルター対応）

## Test plan
- [ ] `npm run build` が成功する
- [ ] Zennプロジェクトを `ZENN_PROJECT_DIR` に設定し、`zenn_list_articles` で記事一覧が返る
- [ ] `zenn_read_article` で記事の全文が返る

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)