### PR TITLE
feat: update-article ツール実装

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { readArticleSchema, readArticle } from "./tools/read-article.js";
 import { listArticlesSchema, listArticles } from "./tools/list-articles.js";
 import { createArticleSchema, createArticle } from "./tools/create-article.js";
+import { updateArticleSchema, updateArticle } from "./tools/update-article.js";
 
 const server = new McpServer({
   name: "zenn-content",
@@ -12,6 +13,7 @@ const server = new McpServer({
 server.tool("zenn_read_article", "指定した記事の全内容を返す", readArticleSchema, readArticle);
 server.tool("zenn_list_articles", "記事一覧を取得する", listArticlesSchema, listArticles);
 server.tool("zenn_create_article", "新しい記事を作成する", createArticleSchema, createArticle);
+server.tool("zenn_update_article", "記事のfrontmatterや本文を更新する", updateArticleSchema, updateArticle);
 
 async function main() {
   const transport = new StdioServerTransport();

--- a/src/tools/update-article.ts
+++ b/src/tools/update-article.ts
@@ -1,0 +1,75 @@
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { z } from "zod";
+import { getArticlePath } from "../utils/zenn-path.js";
+import { parseArticle, stringifyArticle } from "../utils/frontmatter.js";
+
+export const updateArticleSchema = {
+  slug: z.string().describe("記事のslug"),
+  title: z.string().optional().describe("新しいタイトル"),
+  emoji: z.string().optional().describe("新しい絵文字"),
+  topics: z.array(z.string()).optional().describe("新しいトピック配列"),
+  type: z.enum(["tech", "idea"]).optional().describe("記事タイプ"),
+  published: z.boolean().optional().describe("公開状態"),
+  body: z.string().optional().describe("新しい本文（全体を置換）"),
+};
+
+export async function updateArticle({
+  slug,
+  title,
+  emoji,
+  topics,
+  type,
+  published,
+  body,
+}: {
+  slug: string;
+  title?: string;
+  emoji?: string;
+  topics?: string[];
+  type?: string;
+  published?: boolean;
+  body?: string;
+}) {
+  const filePath = getArticlePath(slug);
+
+  if (!existsSync(filePath)) {
+    return {
+      content: [
+        { type: "text" as const, text: `記事が見つかりません: ${slug}` },
+      ],
+      isError: true,
+    };
+  }
+
+  const raw = readFileSync(filePath, "utf-8");
+  const article = parseArticle(raw);
+
+  // frontmatterの部分更新（指定されたフィールドだけ上書き）
+  if (title !== undefined) article.frontmatter.title = title;
+  if (emoji !== undefined) article.frontmatter.emoji = emoji;
+  if (topics !== undefined) article.frontmatter.topics = topics;
+  if (type !== undefined) article.frontmatter.type = type as "tech" | "idea";
+  if (published !== undefined) article.frontmatter.published = published;
+
+  // bodyが指定されていれば本文を置換
+  if (body !== undefined) article.body = body;
+
+  writeFileSync(filePath, stringifyArticle(article), "utf-8");
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            slug,
+            ...article.frontmatter,
+            bodyLength: article.body.length,
+          },
+          null,
+          2
+        ),
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- `zenn_update_article` ツールを実装
- frontmatterの部分更新（指定フィールドのみ上書き、既存フィールドは保持）
- bodyが指定された場合のみ本文を置換

## Test plan
- [ ] `npm run build` が成功する
- [ ] titleだけ更新しても他のfrontmatterフィールドが消えない
- [ ] bodyを指定すると本文が置換される
- [ ] 存在しないslugでエラーが返る

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)