### PR TITLE
feat: preview + publish ツール実装

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import { readArticleSchema, readArticle } from "./tools/read-article.js";
 import { listArticlesSchema, listArticles } from "./tools/list-articles.js";
 import { createArticleSchema, createArticle } from "./tools/create-article.js";
 import { updateArticleSchema, updateArticle } from "./tools/update-article.js";
+import { previewSchema, preview } from "./tools/preview.js";
+import { publishSchema, publish } from "./tools/publish.js";
 
 const server = new McpServer({
   name: "zenn-content",
@@ -14,6 +16,8 @@ server.tool("zenn_read_article", "指定した記事の全内容を返す", read
 server.tool("zenn_list_articles", "記事一覧を取得する", listArticlesSchema, listArticles);
 server.tool("zenn_create_article", "新しい記事を作成する", createArticleSchema, createArticle);
 server.tool("zenn_update_article", "記事のfrontmatterや本文を更新する", updateArticleSchema, updateArticle);
+server.tool("zenn_preview", "プレビューサーバーの起動・停止・状態確認", previewSchema, preview);
+server.tool("zenn_publish", "記事を公開する（published: true + git push）", publishSchema, publish);
 
 async function main() {
   const transport = new StdioServerTransport();

--- a/src/tools/preview.ts
+++ b/src/tools/preview.ts
@@ -1,0 +1,92 @@
+import { spawn, type ChildProcess } from "child_process";
+import { z } from "zod";
+import { getZennProjectDir } from "../utils/zenn-path.js";
+
+let previewProcess: ChildProcess | null = null;
+let previewPort: number | null = null;
+
+export const previewSchema = {
+  action: z.enum(["start", "stop", "status"]).describe("start / stop / status"),
+  port: z.number().default(8000).describe("プレビューサーバーのポート番号"),
+};
+
+export async function preview({
+  action,
+  port,
+}: {
+  action: string;
+  port: number;
+}) {
+  if (action === "status") {
+    const running = previewProcess !== null && previewProcess.exitCode === null;
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            running,
+            port: running ? previewPort : null,
+            url: running ? `http://localhost:${previewPort}` : null,
+          }),
+        },
+      ],
+    };
+  }
+
+  if (action === "stop") {
+    if (previewProcess && previewProcess.exitCode === null) {
+      previewProcess.kill();
+      previewProcess = null;
+      previewPort = null;
+      return {
+        content: [
+          { type: "text" as const, text: "プレビューサーバーを停止しました" },
+        ],
+      };
+    }
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: "プレビューサーバーは起動していません",
+        },
+      ],
+    };
+  }
+
+  // action === "start"
+  if (previewProcess && previewProcess.exitCode === null) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `プレビューサーバーは既に起動中です: http://localhost:${previewPort}`,
+        },
+      ],
+    };
+  }
+
+  const projectDir = getZennProjectDir();
+
+  previewProcess = spawn("npx", ["zenn", "preview", "--port", String(port)], {
+    cwd: projectDir,
+    stdio: "ignore",
+    detached: false,
+  });
+
+  previewPort = port;
+
+  previewProcess.on("exit", () => {
+    previewProcess = null;
+    previewPort = null;
+  });
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `プレビューサーバーを起動しました: http://localhost:${port}`,
+      },
+    ],
+  };
+}

--- a/src/tools/publish.ts
+++ b/src/tools/publish.ts
@@ -1,0 +1,81 @@
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { execFileSync } from "child_process";
+import { z } from "zod";
+import { getZennProjectDir, getArticlePath } from "../utils/zenn-path.js";
+import { parseArticle, stringifyArticle } from "../utils/frontmatter.js";
+
+export const publishSchema = {
+  slug: z.string().describe("公開する記事のslug"),
+  commit_message: z
+    .string()
+    .optional()
+    .describe("コミットメッセージ（省略時は自動生成）"),
+};
+
+export async function publish({
+  slug,
+  commit_message,
+}: {
+  slug: string;
+  commit_message?: string;
+}) {
+  const filePath = getArticlePath(slug);
+
+  if (!existsSync(filePath)) {
+    return {
+      content: [
+        { type: "text" as const, text: `記事が見つかりません: ${slug}` },
+      ],
+      isError: true,
+    };
+  }
+
+  const projectDir = getZennProjectDir();
+
+  // published: true に変更
+  const raw = readFileSync(filePath, "utf-8");
+  const article = parseArticle(raw);
+  article.frontmatter.published = true;
+  writeFileSync(filePath, stringifyArticle(article), "utf-8");
+
+  const message =
+    commit_message || `publish: ${article.frontmatter.title || slug}`;
+
+  try {
+    // git add → commit → push
+    execFileSync("git", ["add", `articles/${slug}.md`], { cwd: projectDir });
+    execFileSync("git", ["commit", "-m", message], { cwd: projectDir });
+    execFileSync("git", ["push", "origin", "main"], { cwd: projectDir });
+  } catch (err) {
+    const errorMessage =
+      err instanceof Error ? err.message : "不明なエラーが発生しました";
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `記事を published: true に変更しましたが、git操作に失敗しました: ${errorMessage}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            slug,
+            title: article.frontmatter.title,
+            published: true,
+            commitMessage: message,
+            status: "公開完了（git push済み）",
+          },
+          null,
+          2
+        ),
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- `zenn_preview`: `npx zenn preview` をバックグラウンドで起動/停止/状態確認
- `zenn_publish`: `published: true` に変更し、`git add` → `commit` → `push origin main` を実行
- これで全6ツールが揃い、記事の作成から公開までの一連のフローが完成

## Test plan
- [ ] `npm run build` が成功する
- [ ] `zenn_preview` の start/status/stop が動作する
- [ ] `zenn_publish` で frontmatter が `published: true` に変更される
- [ ] `zenn_publish` で git commit & push が実行される

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)